### PR TITLE
Docs/rustup update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@ Before building and running **nyx-ψ**, ensure that your development environment
 
 - **Rust Compiler**: Version **1.74** or newer is required.
 
-*Update* your toolchain using rustup if necessary. 
+If you need to install rust for the first time run the command below.
+
 ```bash
-rustup update
-rustc --version  // >= 1.74
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh  // installs rust
+```
+
+Update your local toolchain with ```rustup``` if necessary.
+
+```bash
+rustup update  // updates rust
+rustc --version  // output should be >= 1.74
 ```
 
 ## Benchmark Results

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 **nyx-ψ** _(nyxpsi)_ is a next-generation network implementation designed for resilience and efficiency in lossy and unstable network environments. Through innovative networking strategies and error correction mechanisms, **nyx-ψ** delivers reliable data transfer where traditional protocols like TCP and UDP fall short.
 
 Built with scalability and robustness in mind, **nyx-ψ** aims to empower applications that demand high reliability and performance, even in the face of extreme packet loss.
+Results Summary
+
+## Prerequisites
+
+Before building and running **nyx-ψ**, ensure that your development environment meets the following requirements:
+
+- **Rust Compiler**: Version **1.74** or newer is required.
+
+*Update* your toolchain using rustup if necessary. 
+```bash
+rustup update
+rustc --version  // >= 1.74
+```
 
 ## Benchmark Results
 


### PR DESCRIPTION
Minor addition to readme to add prereq section to indicate rustc >= 1.74. 

Why? 
Encountered this issue running ```cargo bench``` (Which is actually still failing due to an E0432 for unresolved import of UdpLiteSocket in src/client.rs and src/server.rs). Initial error told me to update cargo, here to save someone else the google. 
